### PR TITLE
feat(ios): add Batch folder in Framework Search Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,23 @@ The official React Native plugin for the Batch SDK. Made with ❤️ by BAM and 
 
 ### 2. Setup iOS dependencies
 
+#### Cocoapods (Recommended)
+
 - Go to `/ios`
 - If you don't have a Podfile yet run `pod init`
 - Add `pod 'Batch', '~>1.13'` to your _Podfile_
 - Run `pod install`
+
+#### Manual frameworks (Not Recommended)
+
+If you don't use CocoaPods, you can integrate Batch SDK manually.
+
+- Download the [SDK](https://batch.com/doc/ios/advanced/general.html#_manual-sdk-integration)
+- Unzip the SDK
+- Here instead of following the readme inside the Batch.embeddedframework folder you downloaded follow the below steps.
+- Create a Batch folder in `{your-project}/ios/Batch`
+- Copy your Batch framework inside `{your-project}/ios/Batch`
+- Open your project in XCode. Right click your ".xcodeproj" and click "Add Files to {yourProjectName}…". Find the "Batch" folder you created and select it. Before clicking "Add", to the left you'll see an "Options" button. Click it, and make sure "Create Groups" and "Add to targets" for your project are both selected.
 
 ### 3. Link the plugin
 

--- a/ios/RNBatchPush.xcodeproj/project.pbxproj
+++ b/ios/RNBatchPush.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../../node_modules/react-native/React/**",
 					"${SRCROOT}/../../../../ios/Pods/Batch/**",
+					"${SRCROOT}/../../../../ios/Batch/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -237,6 +238,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../../node_modules/react-native/React/**",
 					"${SRCROOT}/../../../../ios/Pods/Batch/**",
+					"${SRCROOT}/../../../../ios/Batch/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RNBatchPush.xcodeproj/project.pbxproj
+++ b/ios/RNBatchPush.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -207,6 +208,7 @@
 					"$(inherited)",
 					"${BUILT_PRODUCTS_DIR}",
 					"${SRCROOT}/../../../../ios/Pods/Batch/**",
+					"${SRCROOT}/../../../../ios/Batch/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -228,6 +230,7 @@
 					"$(inherited)",
 					"${BUILT_PRODUCTS_DIR}",
 					"${SRCROOT}/../../../../ios/Pods/Batch/**",
+					"${SRCROOT}/../../../../ios/Batch/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
# Description 

- [x] add folder batch in Framework Search Paths
- [x] add folder batch in Header Search Paths
- [x] add documentation on Readme to show how to install it

# Motivation

Currently we cannot use [React Native Batch](https://github.com/bamlab/react-native-batch-push) without [Cocoapods](https://cocoapods.org/about). We only have a `Pods/` folder in framework search path.

[React Native Firebase](https://github.com/invertase/react-native-firebase/tree/v5.x.x) actually have two paths in Framework Search Paths and Header Search Paths. One for Pods and another one is just `ios/Firebase` in the case the user want manually put the framework.

So this PR add `../ios/Batch` folder in case the user want to add it manually. Some projects for technical reasons do not have [Cocoapods](https://cocoapods.org/about). Even though I highly recommend to use [Cocoapods](https://cocoapods.org/about)