### PR TITLE
Allow date to be passed in milliseconds

### DIFF
--- a/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
+++ b/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
@@ -239,7 +239,7 @@ public class RNBatchModule extends ReactContextBaseJavaModule implements Lifecyc
                 }
             } else if (type.equals("setDateAttribute")) {
                 String key = action.getString("key");
-                long timestamp = action.getInt("value");
+                long timestamp = (long) action.getDouble("value");
                 Date date = new Date(timestamp);
                 editor.setAttribute(key, date);
             } else if (type.equals("removeAttribute")) {


### PR DESCRIPTION
If we pass date just in seconds, the constructor of `Date` will return the default Date (01.01.1970) as it should take timestamp in milliseconds.

If we pass it in milliseconds, `getInt()` method will cut it and the result will be the same.