### PR TITLE
Fix typo in RNBatchModule.java

### DIFF
--- a/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
+++ b/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
@@ -143,7 +143,7 @@ public class RNBatchModule extends ReactContextBaseJavaModule implements Lifecyc
     // MESSAGING MODULE
 
     @ReactMethod
-    public void messaging_showPendingMessages() {
+    public void messaging_showPendingMessage() {
         Boolean test = Batch.Messaging.isDoNotDisturbEnabled();
         BatchMessage msg = Batch.Messaging.popPendingMessage();
         if (msg != null) {


### PR DESCRIPTION
## Problem

There is an error when calling BatchMessaging.showPendingMessage() on Android.

## Why 

In Android module function is export with name `messaging_showPendingMessages` instead of `messaging_showPendingMessage` like it is required in `BatchMessaging.js`.

The name is correct in Obj-C