### PR TITLE
(setNotDisturbed) Finish bridge implementation

### DIFF
--- a/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
+++ b/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
@@ -151,6 +151,11 @@ public class RNBatchModule extends ReactContextBaseJavaModule implements Lifecyc
         }
     }
 
+    @ReactMethod
+    public void messaging_setNotDisturbed(final boolean active) {
+        Batch.Messaging.setDoNotDisturbEnabled(active);
+    }
+
     // INBOX MODULE
 
     private static final int NOTIFICATIONS_COUNT = 100;

--- a/src/BatchMessaging.ts
+++ b/src/BatchMessaging.ts
@@ -7,4 +7,12 @@ export const BatchMessaging = {
    * - Used in conjonction with `Batch.start(true)` to display pending messages
    */
   showPendingMessage: (): void => RNBatch.messaging_showPendingMessage(),
+
+  /**
+   * Define if incoming messages have to be enqueued or displayed directly
+   *
+   * @param active
+   */
+  setNotDisturbed: (active: boolean): void =>
+    RNBatch.messaging_setNotDisturbed(active),
 };


### PR DESCRIPTION
## Objective

Finishing the bridge implementation of `setNotDisturbed` Batch property that was already started for iOS in `RNBatch.m`.