### PR TITLE
[iOS] Fix opening deep link when app is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ Then, in `Info.plist`, provide:
 <string>%YOUR_BATCH_API_KEY%</string>
 ```
 
+#### c. Start Batch in AppDelegate.m
+
+In `AppDelegate.m`, start Batch:
+
+```objective-c
+#import "RNBatch.h"
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    ...
+    [RNBatch start:false]; // or true if you want the do not disturb mode
+    ...
+    return YES;
+}
+```
+
 <hr>
 
 ## Usage

--- a/ios/RNBatch.h
+++ b/ios/RNBatch.h
@@ -7,5 +7,5 @@
 @import Batch;
 
 @interface RNBatch : NSObject <RCTBridgeModule>
-
++ (void)start: (BOOL)doNotDisturb;
 @end

--- a/ios/RNBatch.m
+++ b/ios/RNBatch.m
@@ -10,7 +10,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(start:(BOOL) doNotDisturb)
++ (void)start: (BOOL)doNotDisturb
 {
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
     NSString *batchAPIKey = [info objectForKey:@"BatchAPIKey"];

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 export * from './BatchEventData';
 export * from './BatchInbox';
 export * from './BatchMessaging';
@@ -16,7 +16,14 @@ export const Batch = {
    *
    * @argument doNotDisturb prevents the inbox module from showing on start
    */
-  start: (doNotDisturb: boolean = false): void => RNBatch.start(doNotDisturb),
+  start: (doNotDisturb: boolean = false): void => {
+    if (Platform.OS === 'ios') {
+      // start should be made on native side in didFinishLaunchingWithOptions
+      return;
+    }
+
+    RNBatch.start(doNotDisturb);
+  },
 
   /**
    * Opt In to Batch SDK Usage.


### PR DESCRIPTION
`[Batch startWithAPIKey:batchAPIKey]` swizzles AppDelegate methods and if it's not called in `didFinishLaunchingWithOptions`, push notifications with deeplink won't open the deeplink when the app was closed.