### PR TITLE
feat(android): bump android sdk to 1.15+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.batch.android:batch-sdk:1.13+"
+    implementation "com.batch.android:batch-sdk:1.15+"
 }


### PR DESCRIPTION
The 1.13.0 version is [really old (24/09/2018)](https://doc.batch.com/android/sdk-changelog)
Here is a bump to the latest 1.15+ sdk on android and a fix to display In-App campaigns