### PR TITLE
Fixing missing check for active catalyst instance on react context

### DIFF
--- a/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
+++ b/android/src/main/java/tech/bam/RNBatchPush/RNBatchModule.java
@@ -6,6 +6,7 @@ import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.location.Location;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -141,6 +142,11 @@ public class RNBatchModule extends ReactContextBaseJavaModule implements BatchEv
     private void sendEvent(ReactContext reactContext,
                            String eventName,
                            @Nullable WritableMap params) {
+
+        if (!reactContext.hasActiveCatalystInstance()) {
+            Log.d(NAME, "React context has no active catalyst instance. Aborting send event.");
+            return;
+        }
         reactContext
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);


### PR DESCRIPTION
We have users who have a crash while opening their app from a push notification. Actually the event dispatcher added in the recent versions, try to access the module before the React instance be fully set up.