### PR TITLE
fix: expo 44 build error

### DIFF
--- a/ios/RNBatch.h
+++ b/ios/RNBatch.h
@@ -1,14 +1,5 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
-
-#if __has_include("RCTEventEmitter.h")
-#import "RCTEventEmitter.h"
-#else
 #import <React/RCTEventEmitter.h>
-#endif
 
 @import Batch;
 

--- a/ios/RNBatch.h
+++ b/ios/RNBatch.h
@@ -1,5 +1,14 @@
-#import <React/RCTBridgeModule.h>
-#import <React/RCTEventEmitter.h>
+#if __has_include("React/RCTBridgeModule.h")
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+#endif
+
+#if __has_include("React/RCTEventEmitter.h")
+  #import <React/RCTEventEmitter.h>
+#else
+  #import "RCTEventEmitter.h"
+#endif
 
 @import Batch;
 


### PR DESCRIPTION
Could not upgrade to expo 44 because iOS build was failing.

As explained here: https://github.com/expo/expo/issues/15622#issuecomment-997141629

Old style imports are not supported anymore from expo 44.